### PR TITLE
Chore: Fix example using deprecated `register_error_handlers` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,11 @@ pip install flask-utils
 
 ```python
 from flask import Flask
-from flask_utils import register_error_handlers
+from flask_utils import FlaskUtils
 from flask_utils import BadRequestError
 
 app = Flask(__name__)
-
-register_error_handlers(app)
+utils = FlaskUtils(app, register_error_handlers=True)
 
 @app.route('/')
 def index():


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a short summary of your changes in the Title above -->

## Description
The example usage in the README was still using the deprecated `register_error_handlers` method.
I fixed it to use the FlaskUtils class instead.

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [x] Checked that the pre-commit checks pass (see [your-first-code-contribution](https://github.com/Seluj78/flask-utils/blob/main/CONTRIBUTING.md#your-first-code-contribution) and also [pre-commit](https://docs.pymc.io/en/latest/contributing/python_style.html))
- [x] Checked that all the tests pass (see [your-first-code-contribution](https://github.com/Seluj78/flask-utils/blob/main/CONTRIBUTING.md#your-first-code-contribution))
- [x] Checked that your commit messages follow [the specified guidelines](https://github.com/Seluj78/flask-utils/blob/main/CONTRIBUTING.md#commit-messages)
- [ ] Added necessary documentation (docstrings and/or example notebooks, if applicable)

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [x] Maintenance
- [ ] Other (please specify):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated import statements and usage examples in the README for better clarity and additional parameters.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->